### PR TITLE
Remove ApplicationInsights connection string from output

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -210,7 +210,6 @@ module eventgripdftopic 'br/public:avm/res/event-grid/system-topic:0.6.1' = {
 } 
 
 // App outputs
-output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.connectionString
 output AZURE_LOCATION string = location
 output AZURE_TENANT_ID string = tenant().tenantId
 output SERVICE_PROCESSOR_BASE_URL string = processor.outputs.SERVICE_PROCESSOR_BASE_URL


### PR DESCRIPTION
Propagated from functions-quickstart-dotnet-azd PR #18

**Changes:**
- Removed `APPLICATIONINSIGHTS_CONNECTION_STRING` output from infra/main.bicep

**Context:**
This change aligns with the updates made in Azure-Samples/functions-quickstart-dotnet-azd#18 where app insights outputs were removed from infrastructure template outputs.

**Testing:**
- [ ] Verify infrastructure deployment still works
- [ ] Confirm application insights monitoring still functions via other configuration methods