### PR TITLE
Configure for remote build: add remoteBuild to azure.yaml, update .funcignore

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -18,6 +18,6 @@ hooks:
 services:
   processor:
     project: ./src
-    language: js
+    language: ts
     host: function
     remoteBuild: true

--- a/azure.yaml
+++ b/azure.yaml
@@ -20,3 +20,4 @@ services:
     project: ./src
     language: js
     host: function
+    remoteBuild: true

--- a/src/.funcignore
+++ b/src/.funcignore
@@ -4,6 +4,4 @@
 local.settings.json
 test
 .funcignore
-node_modules/@types/
-node_modules/azure-functions-core-tools/
-node_modules/typescript/
+node_modules


### PR DESCRIPTION
## Summary

Configures the project for remote build when deploying with `azd`.

## Changes

- **azure.yaml**: Added `remoteBuild: true` under the `processor` service
- **src/.funcignore**: Updated to ignore the full `node_modules` directory (previously only ignored specific subdirectories)

## Context

When deploying Node.js/TypeScript Azure Functions apps with `azd`, remote build is used. The `.funcignore` was previously only ignoring specific `node_modules` subdirectories (`@types/`, `azure-functions-core-tools/`, `typescript/`), which means the rest of `node_modules` was being uploaded unnecessarily. This change ignores the entire `node_modules` folder so dependencies are installed during remote build instead.

## About `remoteBuild: true` in `azure.yaml`

The `remoteBuild: true` flag in `azure.yaml` is being added ahead of support in `azd`. See https://github.com/Azure/azure-dev/pull/6748.

Adding this flag now has no effect on current versions of `azd`, but will be used by new versions that support it. The goal is to explicitly pin the remote build behavior for this project so that it is not affected by potential future changes to the default build behavior in `azd`.